### PR TITLE
fix: 🐛 Include _created field in the rvp_split_coords view

### DIFF
--- a/pg-scripts/create-view-rvp.sql
+++ b/pg-scripts/create-view-rvp.sql
@@ -6,5 +6,6 @@ CREATE OR REPLACE VIEW wmfs.rvp_split_coords AS
    SPLIT_PART(coordinates, ', ', 1) as x_coordinate,
    SPLIT_PART(coordinates, ', ', 2) as y_coordinate,
    response_code,
+   _created,
    _modified
    FROM wmfs.rendezvous_points;


### PR DESCRIPTION
Ensures we can include it in the vision-export correctly.

pg-delta-file needs _created and _modified dates to determine the action properly.